### PR TITLE
Parameterized keymaster_storage and home

### DIFF
--- a/files/emailKey.py
+++ b/files/emailKey.py
@@ -1,0 +1,90 @@
+#! /usr/bin/python
+#
+# emailKey.py
+# Script to send user keys
+# https://github.com/shermdog/puppet-sshkeys
+# v1.0
+# 6.28.13
+
+# Params:
+#   filename (absolute path)
+#   emailaddress
+
+import sys
+import socket
+import smtplib
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+
+# Script defaults - You need to set these!
+sender = 'sender@host.com'
+server = 'smtp.server.com'
+port = 465
+user = 'username'
+password = 'password'
+
+
+def printUsage ():
+  print "Incorrect or invalid arguments."
+  print "Usage: emailKey.py <filename> <emailaddress>"
+  sys.exit(2) #Invalid sytax error code
+
+
+# Start main program code
+if len(sys.argv) != 3:
+  printUsage()
+
+fileName = sys.argv[1]
+address = sys.argv[2]
+
+# Create the enclosing (outer) message
+outer = MIMEMultipart()
+outer['Subject'] = 'SSH Access Key Updated'
+outer['From'] = sender
+outer['To'] = address
+
+# Text inside of the email
+body = MIMEText("""Your SSH access key has been updated and is included in this message.
+
+This key will be installed in the next 30 minutes.  Your previous key will be removed.
+
+
+
+
+
+
+
+
+"I am Vinz, Vinz Clortho, Keymaster of Gozer...Volguus Zildrohoar, Lord of the Seboullia. Are you the Gatekeeper?"
+""")
+
+outer.attach(body)
+
+# Attach certificate
+fp = open(fileName, 'rb')
+# SES has some strict MIME types, this allows any extension
+msg = MIMEBase('application', "pgp-encrypted")
+msg.set_payload(fp.read())
+fp.close()
+
+# Encode the payload using Base64
+encoders.encode_base64(msg)
+msg.add_header('Content-Disposition', 'attachment', filename=fileName.rsplit('/',1)[1])
+outer.attach(msg)
+
+# Send email and cath errors
+try:
+    s = smtplib.SMTP_SSL(server, port, timeout=1)
+    s.login(user,password)
+    s.sendmail(sender, address, outer.as_string())
+    s.quit()
+    print "Successfully sent email."
+    sys.exit() #Successful exit code 0
+except Exception, e:    
+    print "Unable to send email. Error: %s" % e
+    sys.exit(1) #Exit with error
+
+# It's over!

--- a/manifests/create_key.pp
+++ b/manifests/create_key.pp
@@ -6,6 +6,7 @@ define sshkeys::create_key (
   $length = 2048,
   $maxdays = "",
   $mindate = "",
+  $email = ""
 ) {
   sshkeys::namecheck { "${title}-title": parm => "title", value => $title }
 
@@ -25,5 +26,6 @@ define sshkeys::create_key (
     length  => $_length,
     maxdays => $maxdays,
     mindate => $mindate,
+    email   => $email
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,2 +1,5 @@
-class sshkeys {
-}
+class sshkeys (
+  $keymaster_storage = $sshkeys::var::keymaster_storage  
+ )
+  inherits sshkeys::var  {
+ }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 class sshkeys (
-  $keymaster_storage = $sshkeys::var::keymaster_storage  
+  $keymaster_storage = $sshkeys::var::keymaster_storage,
+  $home = $sshkeys::var::home  
  )
   inherits sshkeys::var  {
  }

--- a/manifests/keymaster.pp
+++ b/manifests/keymaster.pp
@@ -1,8 +1,8 @@
 # Keymaster host:
 # Create key storage; create, regenerate, and remove key pairs
 class sshkeys::keymaster {
-  include sshkeys::var
-  file { $sshkeys::var::keymaster_storage:
+
+  file { $sshkeys::keymaster_storage:
     ensure => directory,
     owner  => puppet,
     group  => puppet,

--- a/manifests/set_authorized_keys.pp
+++ b/manifests/set_authorized_keys.pp
@@ -9,7 +9,7 @@ define sshkeys::set_authorized_keys (
 ) {
   
   $_keyname = $keyname ? { '' => $title, default => $keyname }
-  $_home = $home ? { "" => "/home/${user}", default => $home }
+  $_home = $home ? { "" => "${sshkeys::home}/${user}", default => $home }
   # on the keymaster:
   $key_src_dir = "${sshkeys::keymaster_storage}/${_keyname}"
   $key_src_file = "${key_src_dir}/key.pub"

--- a/manifests/set_authorized_keys.pp
+++ b/manifests/set_authorized_keys.pp
@@ -12,7 +12,7 @@ define sshkeys::set_authorized_keys (
   $_home = $home ? { "" => "${sshkeys::home}/${user}", default => $home }
   # on the keymaster:
   $key_src_dir = "${sshkeys::keymaster_storage}/${_keyname}"
-  $key_src_file = "${key_src_dir}/key.pub"
+  $key_src_file = "${key_src_dir}/${_keyname}.pub"
   # on the server:
   $key_tgt_file = "${_home}/.ssh/authorized_keys"
 

--- a/manifests/set_authorized_keys.pp
+++ b/manifests/set_authorized_keys.pp
@@ -7,11 +7,11 @@ define sshkeys::set_authorized_keys (
   $options = '',
   $user
 ) {
-  include sshkeys::var
+  
   $_keyname = $keyname ? { '' => $title, default => $keyname }
   $_home = $home ? { "" => "/home/${user}", default => $home }
   # on the keymaster:
-  $key_src_dir = "${sshkeys::var::keymaster_storage}/${_keyname}"
+  $key_src_dir = "${sshkeys::keymaster_storage}/${_keyname}"
   $key_src_file = "${key_src_dir}/key.pub"
   # on the server:
   $key_tgt_file = "${_home}/.ssh/authorized_keys"

--- a/manifests/set_client_key_pair.pp
+++ b/manifests/set_client_key_pair.pp
@@ -7,7 +7,7 @@ define sshkeys::set_client_key_pair (
   $home = '',
   $user
 ) {
-  include sshkeys::var
+
   File {
     owner   => $user,
     group   => $group ? { '' => $user, default => $group },
@@ -17,7 +17,7 @@ define sshkeys::set_client_key_pair (
 
   $_keyname = $keyname ? { '' => $title, default => $keyname }
   $_home = $home ? { '' => "/home/${user}", default => $home }
-  $key_src_file = "${sshkeys::var::keymaster_storage}/${_keyname}/key" # on the keymaster
+  $key_src_file = "${sshkeys::keymaster_storage}/${_keyname}/key" # on the keymaster
   $key_tgt_file = "${_home}/.ssh/${filename}" # on the client
 
   $key_src_content_pub = file("${key_src_file}.pub", "/dev/null")

--- a/manifests/set_client_key_pair.pp
+++ b/manifests/set_client_key_pair.pp
@@ -16,7 +16,7 @@ define sshkeys::set_client_key_pair (
   }
 
   $_keyname = $keyname ? { '' => $title, default => $keyname }
-  $_home = $home ? { '' => "/home/${user}", default => $home }
+  $_home = $home ? { '' => "${sshkeys::home}/${user}", default => $home }
   $key_src_file = "${sshkeys::keymaster_storage}/${_keyname}/key" # on the keymaster
   $key_tgt_file = "${_home}/.ssh/${filename}" # on the client
 

--- a/manifests/set_client_key_pair.pp
+++ b/manifests/set_client_key_pair.pp
@@ -8,17 +8,18 @@ define sshkeys::set_client_key_pair (
   $user
 ) {
 
+
+  $_keyname = $keyname ? { '' => $title, default => $keyname }
+  $_home = $home ? { '' => "${sshkeys::home}/${user}", default => $home }
+  $key_src_file = "${sshkeys::keymaster_storage}/${_keyname}/${_keyname}" # on the keymaster
+  $key_tgt_file = "${_home}/.ssh/${filename}" # on the client
+  
   File {
     owner   => $user,
     group   => $group ? { '' => $user, default => $group },
     mode    => 600,
-    require => [ User[$user], File[$home]],
+    require => [ User[$user], File[$_home]],
   }
-
-  $_keyname = $keyname ? { '' => $title, default => $keyname }
-  $_home = $home ? { '' => "${sshkeys::home}/${user}", default => $home }
-  $key_src_file = "${sshkeys::keymaster_storage}/${_keyname}/key" # on the keymaster
-  $key_tgt_file = "${_home}/.ssh/${filename}" # on the client
 
   $key_src_content_pub = file("${key_src_file}.pub", "/dev/null")
   if $ensure == "absent" or $key_src_content_pub =~ /^(ssh-...) ([^ ]+)/ {

--- a/manifests/setup_key_master.pp
+++ b/manifests/setup_key_master.pp
@@ -8,7 +8,8 @@ define sshkeys::setup_key_master (
   $keytype,
   $length,
   $maxdays,
-  $mindate
+  $mindate,
+  $email
 ) {
 
   Exec { path => "/usr/bin:/usr/sbin:/bin:/sbin" }
@@ -19,7 +20,8 @@ define sshkeys::setup_key_master (
   }
 
   $keydir = "${sshkeys::keymaster_storage}/${title}"
-  $keyfile = "${keydir}/key"
+  
+  $keyfile = "${keydir}/${title}"
 
   file {
     "$keydir":
@@ -83,5 +85,21 @@ define sshkeys::setup_key_master (
       require => File[$keydir],
       before  => File[$keyfile, "${keyfile}.pub"],
     }
+    
+    if $email {
+	    # Command to email key to user
+	    # Idea courtesy of http://www.warden.pl/2012/09/05/puppet-send-an-email-to-the-client-when-a-new-key-is-generated/
+	    exec { "Notify user ${email}":
+	      command => "/usr/bin/python /common/puppet/emailKey.py ${keyfile} ${email}",	      
+	      timeout => 30,
+	      tries => 3,
+	      try_sleep => 10,
+	      require => File[$keyfile],
+	      subscribe => Exec["Create key $title: $keytype, $length bits"],
+	      refreshonly => true
+	    }      
+    }
   }
 }
+
+# I am Vinz, Vinz Clortho, Keymaster of Gozer...Volguus Zildrohoar, Lord of the Seboullia. Are you the Gatekeeper?

--- a/manifests/setup_key_master.pp
+++ b/manifests/setup_key_master.pp
@@ -10,7 +10,7 @@ define sshkeys::setup_key_master (
   $maxdays,
   $mindate
 ) {
-  include sshkeys::var
+
   Exec { path => "/usr/bin:/usr/sbin:/bin:/sbin" }
   File {
     owner => puppet,
@@ -18,7 +18,7 @@ define sshkeys::setup_key_master (
     mode  => 600,
   }
 
-  $keydir = "${sshkeys::var::keymaster_storage}/${title}"
+  $keydir = "${sshkeys::keymaster_storage}/${title}"
   $keyfile = "${keydir}/key"
 
   file {

--- a/manifests/var.pp
+++ b/manifests/var.pp
@@ -1,4 +1,4 @@
-class sshkeys::var(
+class sshkeys::var {
   $keymaster_storage = "/var/lib/puppet-sshkeys"
-) {
+  $home = "/home"
 }


### PR DESCRIPTION
I updated the keymaster_storage and home variables to allow them to be overridden when declaring the class:

```
  class{'sshkeys':
    keymaster_storage => '/common/puppet/keys',
    home => '/common/home',
  }

  # Put private key for internal access to home directory
  sshkeys::set_client_key_pair{'rsherman-internal':
    keyname => 'rsherman_internal',
    user => 'rsherman',
  }

  # Enable internal access key
  sshkeys::set_authorized_keys{'rsherman-internal':
    keyname => 'rsherman_internal',
    user => 'rsherman',
  }


```
